### PR TITLE
Fix console example when it doesn't receive the directory to watch

### DIFF
--- a/console/main.cpp
+++ b/console/main.cpp
@@ -32,6 +32,7 @@ int main(int argc, char *argv[])
 {
     if (argc < 2) {
         std::cout << "one input parameter is needed" << std::endl;
+        return 1;
     }
 
     const auto path = std::filesystem::path(argv[1]);


### PR DESCRIPTION
This is a simple fix, when the `PanoptesConsole` example is called without args the example should stop immediately.